### PR TITLE
Add ssh-agent plugin

### DIFF
--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -73,3 +73,4 @@ github-oauth:0.33
 slack:2.34
 configuration-as-code-secret-ssm:1.0.0
 cucumber-reports:5.02
+ssh-agent:1.19


### PR DESCRIPTION
Add plugin which lets us use SSH to connect to GitHub. This makes it easier to push updates like tags and environment-specific branches from Jenkins builds.