### PR TITLE
Remove Jenkins admin users

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -39,7 +39,7 @@ jenkins:
   - "Ping"
   authorizationStrategy:
     github:
-      adminUserNames: "MancunianSam,Dclipsham,ian-hoyle,LauraDamianTNA,MarkKingsbury,plembke-tna,sarrahdi,suzannehamilton,TomJKing,paulschwarzenberger"
+      adminUserNames: "MancunianSam,Dclipsham,ian-hoyle,MarkKingsbury,suzannehamilton,TomJKing,paulschwarzenberger"
       allowAnonymousJobStatusPermission: false
       allowAnonymousReadPermission: false
       allowCcTrayPermission: true


### PR DESCRIPTION
Remove users who have left TNA or who do not need access to Jenkins.