### PR TITLE
Replace github username and password with SSH key

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -12,11 +12,15 @@ credentials:
           password: ${/mgmt/docker/password}
           id: "docker"
           scope: GLOBAL
-      - usernamePassword:
-          username: ${/mgmt/github/username}
-          password: ${/mgmt/github/password}
-          id: "github"
+      - basicSSHUserPrivateKey:
           scope: GLOBAL
+          id: "github-jenkins"
+          username: "tna-digital-archiving-jenkins"
+          passphrase: ""
+          description: "SSH Credentials for github Jenkins user"
+          privateKeySource:
+            directEntry:
+              privateKey: ${/mgmt/github/jenkins-ssh-key}
       - string:
           id: "slack"
           scope: GLOBAL


### PR DESCRIPTION
This makes it easier to let Jenkins jobs to push changes back to github.

Jenkins clones the repo using the public URL, which you can only push change to if you are using an SSH key for authentication. Pushing changes with a password would require you to add the username and password to the git URL.