### PR TITLE
remove rules from default security group

### DIFF
--- a/terraform/modules/jenkins/network.tf
+++ b/terraform/modules/jenkins/network.tf
@@ -11,6 +11,11 @@ resource "aws_vpc" "main" {
   )
 }
 
+# Bring default security group under Terraform management and remove all rules
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+}
+
 # Create var.az_count private subnets, each in a different AZ
 resource "aws_subnet" "private" {
   count             = var.az_count


### PR DESCRIPTION
AWS automatically creates a default security group with each VPC, which can't be deleted. This change brings the default security group under Terraform management and removes all rules.