### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,24 @@ pipeline {
         }
         steps {
             script {
-                sh "tar -zcf jenkins-backup.tar.gz -C /var/jenkins_home/ jobs"
-                sh 'aws s3 cp jenkins-backup.tar.gz s3://tdr-jenkins-backup-mgmt/jenkins-backup-`date +"%Y-%m-%d:%H:%M"`.tar.gz'
+                dir("/tmp") {
+                    // Clean up old backups
+                    sh "rm -rf jobs jenkins-backup.tar.gz"
+                    // Copy jobs folder
+                    sh "cp -R /var/jenkins_home/jobs ."
+                    // Delete the current build so it doesn't show as running when Jenkins restores
+                    sh "rm -rf jobs/TDR\\ Jenkins\\ Backup/builds/$BUILD_NUMBER"
+                    sh "tar -zcf jenkins-backup.tar.gz jobs"
+                    sh 'aws s3 cp jenkins-backup.tar.gz s3://tdr-jenkins-backup-mgmt/jenkins-backup-`date +"%Y-%m-%d:%H:%M"`.tar.gz'
+                }
+
             }
         }
     }
   }
+   post {
+          failure {
+              slackSend color: "danger", message: "*Transfer frontend* :jenkins-fail: The Jenkins backup has failed", channel: "#tdr-releases"
+          }
+      }
 }


### PR DESCRIPTION
This now does three new things.

It copies the jobs folder into the /tmp directory. This stops tar
complaining that the folder is being modified in case anyone is changing
the jobs

It also deletes the currently running backup
build from the folder. This stops the job showing as running when
Jenkins restores.

Finally, it sends a message to slack if the build fails so we know
if it's failing.