### PR TITLE
Give Jenkins permission to read npm_token parameter

### DIFF
--- a/terraform/modules/jenkins/ecs.tf
+++ b/terraform/modules/jenkins/ecs.tf
@@ -201,7 +201,8 @@ data "aws_iam_policy_document" "api_ecs_task_policy_document" {
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/fargate_security_group",
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/docker/username",
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/docker/password",
-      "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/access_key"
+      "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/access_key",
+      "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/npm_token"
     ]
   }
   statement {


### PR DESCRIPTION
This token is used to publish JavaScript libraries built by Jenkins.