### PR TITLE
Remove /var/jenkins_home mount from Jenkins container

### DIFF
--- a/terraform/modules/jenkins/ecs.tf
+++ b/terraform/modules/jenkins/ecs.tf
@@ -29,11 +29,6 @@ resource "aws_ecs_task_definition" "jenkins_task" {
   task_role_arn            = aws_iam_role.api_ecs_task.arn
 
   volume {
-    name      = "jenkins"
-    host_path = "/var/lib/docker/volumes/ecs-jenkins"
-  }
-
-  volume {
     name      = "docker_bin"
     host_path = "/usr/bin/docker"
   }

--- a/terraform/modules/jenkins/templates/jenkins.json.tpl
+++ b/terraform/modules/jenkins/templates/jenkins.json.tpl
@@ -26,10 +26,6 @@
         "essential": true,
         "mountPoints": [
           {
-            "sourceVolume": "jenkins",
-            "containerPath": "/var/jenkins_home"
-          },
-          {
             "sourceVolume": "docker_bin",
             "containerPath": "/usr/bin/docker"
           },


### PR DESCRIPTION
This directory contains Jenkins dependencies like plugins, build definitions and build histories.

This directory was originally mounted from the EC2 instance so that we could preserve its contents between ECS container deployments. This turned out not to be sufficient, so we then added a backup restore process which restores the build history to the container when it starts up.

This means that the EC2 directory mount is no longer necessary, because the container gets all of the Jenkins configuration from the combination of the image and the restored backup.