### PR TITLE
Remove deprecated adminAddress config value

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -232,7 +232,6 @@ unclassified:
     adminAddress: "address not configured yet <nobody@nowhere>"
     url: "https://jenkins.tdr-prototype.co.uk"
   mailer:
-    adminAddress: "address not configured yet <nobody@nowhere>"
     charset: "UTF-8"
     useSsl: false
   pollSCM:


### PR DESCRIPTION
The `adminAddress` value has been deprecated: https://github.com/jenkinsci/mailer-plugin/blob/62f0d0fa7c58f651d898f656b7e9b7c12011fe95/src/main/java/hudson/tasks/Mailer.java#L278

When we tried to upgrade the Jenkins plugins, it failed with the error:

```
2020-04-17 13:54:31.521+0000 [id=26]	SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed ConfigurationAsCode.init
io.jenkins.plugins.casc.ConfiguratorException: 'adminAddress' is deprecated
...
Caused: io.jenkins.plugins.casc.ConfiguratorException: unclassified: error configuring 'unclassified' with class io.jenkins.plugins.casc.impl.configurators.GlobalConfigurationCategoryConfigurator configurator
```

From that documentation, it looks like the `adminAddress` in the `mailer` section has been deprecated in favour of the one in the `location` section, so this commit removes the deprecated one and leaves the location one.