### PR TITLE
Increase the health check threshold

### DIFF
--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -34,17 +34,18 @@ module "jenkins" {
 }
 
 module "jenkins_alb" {
-  source                = "./tdr-terraform-modules/alb"
-  project               = var.project
-  function              = var.function
-  environment           = local.environment
-  alb_log_bucket        = module.jenkins_logs_s3.s3_bucket_id
-  alb_security_group_id = module.jenkins.alb_security_group_id
-  domain_name           = var.domain_name
-  public_subnets        = module.jenkins.public_subnets
-  target_id             = module.jenkins.instance_id
-  vpc_id                = module.jenkins.vpc_id
-  common_tags           = local.common_tags
+  source                           = "./tdr-terraform-modules/alb"
+  project                          = var.project
+  function                         = var.function
+  environment                      = local.environment
+  alb_log_bucket                   = module.jenkins_logs_s3.s3_bucket_id
+  alb_security_group_id            = module.jenkins.alb_security_group_id
+  health_check_unhealthy_threshold = 5
+  domain_name                      = var.domain_name
+  public_subnets                   = module.jenkins.public_subnets
+  target_id                        = module.jenkins.instance_id
+  vpc_id                           = module.jenkins.vpc_id
+  common_tags                      = local.common_tags
 }
 
 module "jenkins_logs_s3" {


### PR DESCRIPTION
Increase the unhealthy check threshold from the default (2) to 5. This is the number of times that a healthcheck has to fail before ECS deploys a new container.

Healthchecks currently run every 30 seconds. The previous limit meant that the Jenkins container would be redeployed if Jenkins didn't response to the healthcheck within a minute. That meant that we couldn't soft-restart the Jenkins service, which takes around 90 seconds to restart.

Increasing this threshold means that Jenkins might be down for a few minutes before ECS tries to resolve the problem, but we don't expect that to be a big problem because Jenkins is developer-facing and we'll be able to investigate any problems that arise in practice.

Depends on a change to the modules repo: https://github.com/nationalarchives/tdr-terraform-modules/pull/17