### PR TITLE
Add credentials for Jenkins API key

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -22,6 +22,10 @@ credentials:
             directEntry:
               privateKey: "${/mgmt/github/jenkins-ssh-key}"
       - string:
+          id: "github-jenkins-api-key"
+          scope: GLOBAL
+          secret: ${/mgmt/github/jenkins-api-key}
+      - string:
           id: "slack"
           scope: GLOBAL
           secret: ${/mgmt/slack/token}


### PR DESCRIPTION
This will let us update the GitHub branch status based on the Jenkins build output.

https://national-archives.atlassian.net/browse/TDR-142