### PR TITLE
Give Jenkins permission to read GitHub API key

### DIFF
--- a/terraform/modules/jenkins/ecs.tf
+++ b/terraform/modules/jenkins/ecs.tf
@@ -189,6 +189,7 @@ data "aws_iam_policy_document" "api_ecs_task_policy_document" {
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/jenkins_cluster_arn",
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/intg_account",
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/github/secret",
+      "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/github/jenkins-api-key",
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/github/jenkins-ssh-username",
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/github/jenkins-ssh-key",
       "arn:aws:ssm:eu-west-2:${data.aws_caller_identity.current.account_id}:parameter/mgmt/github/client",


### PR DESCRIPTION
This API key is used to report the status of Jenkins branch builds to GitHub.