### PR TITLE
Split out event mapping scripts.

### DIFF
--- a/docker/aws/deploy_lambda_from_s3.py
+++ b/docker/aws/deploy_lambda_from_s3.py
@@ -13,6 +13,4 @@ client = boto_session.client("lambda")
 
 client.update_function_code(FunctionName=function_name, S3Bucket=s3_bucket, S3Key=s3_key)
 response = client.publish_version(FunctionName=function_name)
-function_arn = 'arn:aws:lambda:eu-west-2:' + account_number + ':function:' + function_name
-version = response["Version"]
-print("v" + version)
+print(response["Version"])

--- a/docker/aws/deploy_lambda_from_s3.py
+++ b/docker/aws/deploy_lambda_from_s3.py
@@ -14,8 +14,5 @@ client = boto_session.client("lambda")
 client.update_function_code(FunctionName=function_name, S3Bucket=s3_bucket, S3Key=s3_key)
 response = client.publish_version(FunctionName=function_name)
 function_arn = 'arn:aws:lambda:eu-west-2:' + account_number + ':function:' + function_name
-event_mappings = client.list_event_source_mappings()['EventSourceMappings']
 version = response["Version"]
-uuid = list(filter(lambda x: x['FunctionArn'].startswith(function_arn), event_mappings))[0]['UUID']
-client.update_event_source_mapping(UUID=uuid, FunctionName=function_arn + ":" + version)
 print("v" + version)

--- a/docker/aws/update_event_mapping.py
+++ b/docker/aws/update_event_mapping.py
@@ -1,0 +1,15 @@
+import sys
+from sessions import get_session
+
+account_number = sys.argv[1]
+stage = sys.argv[2]
+function_name = sys.argv[3]
+version = sys.argv[4]
+
+function_arn = f'arn:aws:lambda:eu-west-2:{account_number}:function:{function_name}'
+boto_session = get_session(account_number, "TDRJenkinsLambdaRole" + stage.capitalize())
+
+client = boto_session.client("lambda")
+event_mappings = client.list_event_source_mappings()['EventSourceMappings']
+uuid = list(filter(lambda x: x['FunctionArn'].startswith(function_arn), event_mappings))[0]['UUID']
+client.update_event_source_mapping(UUID=uuid, FunctionName=function_arn + ":" + version)


### PR DESCRIPTION
If we want to be able to roll back or deploy changes from a specific
branch, then we need the event source mapping to be separate, so we can
point the sqs queue to a specific version of the code.