### PR TITLE
Add link to shared jenkinslib repo

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -232,6 +232,15 @@ unclassified:
     hookUrl: "https://jenkins.tdr-prototype.co.uk"
   gitSCM:
     createAccountBasedOnEmail: false
+  globalLibraries:
+    libraries:
+      - name: "tdr-jenkinslib"
+        retriever:
+          modernSCM:
+            scm:
+              git:
+                remote: "https://github.com/nationalarchives/tdr-jenkinslib.git"
+                credentialsId: "github-jenkins-api-key"
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"
     url: "https://jenkins.tdr-prototype.co.uk"


### PR DESCRIPTION
This is with added credentials, but these may not be needed as the jenkinslib repo is public. 
This change facilitates the use of our new jenkinslib of functions so we can utilise groovy functions across all TDR Jenkins jobs and keep code DRY.

This was done with help from @TomJKing 