### PR TITLE
Add default branch to config

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -235,12 +235,13 @@ unclassified:
   globalLibraries:
     libraries:
       - name: "tdr-jenkinslib"
+        defaultVersion: master
+        implicit: true
         retriever:
           modernSCM:
             scm:
               git:
                 remote: "https://github.com/nationalarchives/tdr-jenkinslib.git"
-                credentialsId: "github-jenkins-api-key"
   location:
     adminAddress: "address not configured yet <nobody@nowhere>"
     url: "https://jenkins.tdr-prototype.co.uk"


### PR DESCRIPTION
Missing default branch for global library

Remove credentials as not needed as library is public

Add implicit load option so @Library annotation is not needed in groovy scripts to import the library