### PR TITLE
Flow logs to S3

### DIFF
--- a/terraform/modules/jenkins/flowlogs.tf
+++ b/terraform/modules/jenkins/flowlogs.tf
@@ -5,6 +5,13 @@ resource "aws_flow_log" "jenkins_flowlog" {
   vpc_id          = aws_vpc.main.id
 }
 
+resource "aws_flow_log" "jenkins_flowlog_s3" {
+  log_destination_type = "s3"
+  log_destination      = "arn:aws:s3:::tdr-log-data-mgmt/flowlogs/${var.environment}/jenkins/"
+  traffic_type         = "ALL"
+  vpc_id               = aws_vpc.main.id
+}
+
 resource "aws_cloudwatch_log_group" "jenkins_flowlog_log_group" {
   name = "/flowlogs/tdr-jenkins-vpc-${var.environment}"
   tags = merge(

--- a/terraform/modules/jenkins/outputs.tf
+++ b/terraform/modules/jenkins/outputs.tf
@@ -13,7 +13,3 @@ output "public_subnets" {
 output "vpc_id" {
   value = aws_vpc.main.id
 }
-
-output "cloudwatch_log_group_name" {
-  value = aws_cloudwatch_log_group.jenkins_flowlog_log_group.name
-}

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -74,15 +74,6 @@ module "jenkins_backup_s3" {
   common_tags = local.common_tags
 }
 
-module "jenkins_vpc_flow_logs_firehose" {
-  source                    = "./tdr-terraform-modules/kinesisfirehose"
-  project                   = "tdr"
-  function                  = "jenkins"
-  common_tags               = local.common_tags
-  destination_bucket        = "tdr-log-data-mgmt"
-  cloudwatch_log_group_name = module.jenkins.cloudwatch_log_group_name
-}
-
 module "s3_publish" {
   source = "./modules/s3-publish-build-task"
 }


### PR DESCRIPTION
Stream VPC flowlogs directly to S3, and remove the Kinesis Firehose stream from CloudWatch logs to S3.

This ensures the logs arrive in S3 in a format compatible with Athena searches.