### PR TITLE
Add missing repositories to ECR

### DIFF
--- a/docker/aws/Dockerfile
+++ b/docker/aws/Dockerfile
@@ -1,4 +1,5 @@
-FROM nationalarchives/jenkins-build-python:3.7
+ARG ACCOUNT_NUMBER
+FROM $ACCOUNT_NUMBER.dkr.ecr.eu-west-2.amazonaws.com/jenkins-build-python:3.7
 USER root
 RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
     && python3 get-pip.py \

--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -62,6 +62,7 @@ data "aws_iam_policy_document" "jenkins_fargate_policy_document" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsBuildAwsExecutionRole",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsBuildTerraformExecutionRole",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsBuildTransferFrontendExecutionRole",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsBuildPostgresExecutionRole",
       "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.current.account_id}:task-definition/*:*",
       "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.current.account_id}:cluster/${aws_ecs_cluster.jenkins_cluster.name}",
       "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.current.account_id}:task/*",

--- a/terraform/modules/jenkins/templates/s3publish.json.tpl
+++ b/terraform/modules/jenkins/templates/s3publish.json.tpl
@@ -2,7 +2,7 @@
     {
       "cpu": 1024,
       "memory": 4096,
-      "image": "nationalarchives/jenkins-build-sbt",
+      "image": "${account}.dkr.ecr.eu-west-2.amazonaws.com/jenkins-build-postgres",
       "name": "sonatype",
       "taskRoleArn": "arn:aws:iam::${account}:role/TDRJenkinsPublishRole",
       "compatibilities": ["FARGATE"],

--- a/terraform/modules/s3-publish-build-task/ecs.tf
+++ b/terraform/modules/s3-publish-build-task/ecs.tf
@@ -16,4 +16,5 @@ resource "aws_ecs_task_definition" "s3_publish_task" {
   cpu                      = "2048"
   memory                   = "4096"
   task_role_arn            = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsPublishRole"
+  execution_role_arn       = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsBuildPostgresExecutionRole"
 }

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -142,3 +142,31 @@ module "jenkins_build_transfer_frontend_execution_role" {
   name           = "transfer-frontend"
   repository_arn = module.ecr_jenkins_build_transfer_frontend_repository.repository.arn
 }
+
+module "ecr_jenkins_build_python_repository" {
+  source           = "./tdr-terraform-modules/ecr"
+  name             = "jenkins-build-python"
+  common_tags      = local.common_tags
+  policy_name      = "jenkins_policy"
+  policy_variables = { role_arn = module.jenkins_build_python_execution_role.role_arn }
+}
+
+module "jenkins_build_python_execution_role" {
+  source         = "./modules/build-role"
+  name           = "python"
+  repository_arn = module.ecr_jenkins_build_python_repository.repository.arn
+}
+
+module "ecr_jenkins_build_postgres_repository" {
+  source           = "./tdr-terraform-modules/ecr"
+  name             = "jenkins-build-postgres"
+  common_tags      = local.common_tags
+  policy_name      = "jenkins_policy"
+  policy_variables = { role_arn = module.jenkins_build_postgres_execution_role.role_arn }
+}
+
+module "jenkins_build_postgres_execution_role" {
+  source         = "./modules/build-role"
+  name           = "postgres"
+  repository_arn = module.ecr_jenkins_build_postgres_repository.repository.arn
+}


### PR DESCRIPTION
We don't use these directly so I forgot about them.
One is the base image with python3.7 we use for AWS and one is the image
we use for the database migrations.