### PR TITLE
Use role for ecs plugin

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -3,10 +3,9 @@ credentials:
     domainCredentials:
     - credentials:
       - aws:
-          accessKey: "${/mgmt/access_key}"
+          iamRoleArn: "arn:aws:iam::${/mgmt/management_account}:role/TDRJenkinsFargateRoleMgmt"
           id: "aws"
           scope: GLOBAL
-          secretKey: "${/mgmt/secret_key}"
       - usernamePassword:
           username: ${/mgmt/docker/username}
           password: ${/mgmt/docker/password}

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -34,7 +34,7 @@ jquery-detached:1.2.1
 jquery3-api:3.5.1-1
 jsch:0.1.55.2
 junit:1.32
-lockable-resources:2.8
+lockable-resources:2.10
 mailer:1.32.1
 matrix-project:1.17
 momentjs:1.1.1
@@ -56,7 +56,7 @@ plain-credentials:1.7
 plugin-util-api:1.2.5
 resource-disposer:0.14
 scm-api:2.6.3
-script-security:1.74
+script-security:1.75
 slack:2.41
 snakeyaml-api:1.26.4
 ssh-agent:1.20

--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -50,6 +50,7 @@ data "aws_iam_policy_document" "jenkins_fargate_policy_document" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeLambdaRoleProd",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeLambdaRoleIntg",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsPublishRole",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRTerraformRoleMgmt",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeReadParamsRoleIntg",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeReadParamsRoleStaging",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeReadParamsRoleProd",
@@ -119,4 +120,14 @@ data "aws_iam_policy_document" "fargate_policy" {
       "*",
     ]
   }
+}
+
+resource "aws_iam_role" "jenkins_ecs_role" {
+  assume_role_policy = templatefile("${path.module}/templates/assume_role_policy.json.tpl", {role_arn = aws_iam_role.api_ecs_task.arn})
+  name = "TDRJenkinsFargateRole${title(var.environment)}"
+}
+
+resource "aws_iam_role_policy_attachment" "jenkins_ecs_role_attach" {
+  policy_arn = aws_iam_policy.jenkins_fargate_policy.arn
+  role = aws_iam_role.jenkins_ecs_role.id
 }

--- a/terraform/modules/jenkins/templates/assume_role_policy.json.tpl
+++ b/terraform/modules/jenkins/templates/assume_role_policy.json.tpl
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${role_arn}"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}


### PR DESCRIPTION
The aws-credentials plugin that we use to store the credentials for the ECS plugin allow you to specify a role in place of an access key and secret key. 
This sets up the role and configures jenkins to use it. This means that we can get rid of the jenkins-ecs IAM user.