### PR TITLE
Set access permissions to false

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -48,10 +48,10 @@ jenkins:
       adminUserNames: "MancunianSam,Dclipsham,ian-hoyle,suzannehamilton,TomJKing,Lholbourn,techncl"
       allowAnonymousJobStatusPermission: false
       allowAnonymousReadPermission: false
-      allowCcTrayPermission: true
-      allowGithubWebHookPermission: true
+      allowCcTrayPermission: false
+      allowGithubWebHookPermission: false
       authenticatedUserCreateJobPermission: false
-      authenticatedUserReadPermission: true
+      authenticatedUserReadPermission: false
       organizationNames: "nationalarchives"
       useRepositoryPermissions: true
   clouds:


### PR DESCRIPTION
authenticatedUserReadPermission was allowing anyone with a github account to see the Jenkins jobs so this can be disabled.
The other two weren't causing problems as such but we don't need them so we may as well switch them off.