### PR TITLE
Add symlink to launch jar.

### DIFF
--- a/docker/sbt/Dockerfile
+++ b/docker/sbt/Dockerfile
@@ -3,6 +3,6 @@ USER root
 WORKDIR /opt
 RUN apk update && apk add curl postgresql && \
     curl -Ls https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz | tar --strip-components=1 -xzvf - && \
-    ln /opt/bin/sbt /usr/local/bin/sbt
+    ln /opt/bin/sbt /usr/local/bin/sbt && ln /opt/bin/sbt-launch.jar /usr/local/bin/sbt-launch.jar
 USER jenkins
 RUN echo "*:*:*:*:password" > /home/jenkins/.pgpass && chmod 600 /home/jenkins/.pgpass


### PR DESCRIPTION
The database migration publish job was failing because it couldn't find
the sbt-launch.jar file. I don't know why this doesn't affect the front
end build because those docker files are identical in terms of
installing sbt but there you go.
I've added another symlink to the launch jar and the build is working
now.
