### PR TITLE
Configure Jenkins backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,25 +74,40 @@ I see the way forward with this would be to have a container with an environment
 
 Secrets are set manually in the aws ssm parameter store and these in turn are used to set credentials using the configuration as code plugin.
 
-## Deploying
+## Deployment
+
+Before doing any Jenkins deployments:
+
+- Warn the other developers, in case they are actively using Jenkins
+- Run a manual backup - see the Backups section below. If you do not do this,
+  the Jenkins job numbers and git version tags may get out of sync, which means
+  you will have to [reset the Jenkins build numbers][reset-builds]
+
+[reset-builds]: https://github.com/nationalarchives/tdr-dev-documentation/blob/master/manual/reset-jenkins-builds.md
+
+### Deploy Jenkins Docker image
 
 ```bash
 docker login -u username -p
 cd docker
 docker build -t nationalarchives/jenkins:mgmt .
 docker push nationalarchives/jenkins:mgmt
+```
 
-cd ../terraform
+### Deploy Jenkins EC2 instance and Terraform config
+
+```bash
+cd terraform
 terraform apply
 ```
 
-## Jenkins node images
+### Deploy Jenkins node images
 
 For each project which we need to build, there needs to be a docker image which
 Jenkins can use to build this. For example, there is a
 [Dockerfile](docker/sbt/Dockerfile) for sbt.
 
-### Update a container
+#### Update a container
 
 Once you have changed the Dockerfile for a Jenkins node, build the image and
 push it to Docker Hub by going to the directory for the node (e.g. docker/sbt).
@@ -103,7 +118,7 @@ Log into Docker as above if necessary, then run:
   docker push nationalarchives/jenkins-build-<name-of-node>:latest
   ```
 
-### Adding a new container
+#### Add a new container
 
 The docker container must start with `FROM jenkins/jnlp-slave` This image is mostly stock ubuntu and from there, you need to install whatever it is you need for your build. Build the docker image and push to docker hub.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jenkins prototype for TDR
+# Jenkins Continuous Integration server for TDR
 
 All TDR documentation is available [here](https://github.com/nationalarchives/tdr-dev-documentation)
 

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -10,7 +10,7 @@ resource "aws_instance" "jenkins" {
   tags = merge(
     var.common_tags,
     map(
-      "Name", "${var.container_name}-task-definition-${var.environment}",
+      "Name", var.ec2_instance_name,
     )
   )
 }
@@ -89,5 +89,3 @@ data "aws_iam_policy_document" "ecs_policy" {
     ]
   }
 }
-
-

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -16,6 +16,10 @@ variable "domain_name" {}
 
 variable "dns_zone" {}
 
+variable "ec2_instance_name" {
+  type = string
+}
+
 variable "encrypted_ami_id" {}
 
 variable "environment" {}

--- a/terraform/root_data.tf
+++ b/terraform/root_data.tf
@@ -12,3 +12,7 @@ data "aws_ami" "ecs_ami" {
   name_regex  = "^amzn2-ami-ecs-hvm-2.0.\\d{8}-x86_64-ebs"
   most_recent = true
 }
+
+data "aws_ssm_parameter" "jenkins_backup_healthcheck_url" {
+  name = "/mgmt/jenkins/backup/healthcheck/url"
+}

--- a/terraform/root_locals.tf
+++ b/terraform/root_locals.tf
@@ -8,4 +8,5 @@ locals {
     "Terraform", true,
     "CostCentre", data.aws_ssm_parameter.cost_centre.value
   )
+  ec2_instance_name = "jenkins-task-definition-${local.environment}"
 }

--- a/terraform/root_provider.tf
+++ b/terraform/root_provider.tf
@@ -1,3 +1,4 @@
 provider "aws" {
   region = local.aws_region
+  version = 2.69
 }

--- a/terraform/root_provider.tf
+++ b/terraform/root_provider.tf
@@ -1,4 +1,4 @@
 provider "aws" {
-  region = local.aws_region
+  region  = local.aws_region
   version = 2.69
 }


### PR DESCRIPTION
Use AWS Systems Manager Maintenance Window to set up a daily Jenkins backup.

This commit moves the Maintenance Windows config from tdr-terraform-backend (https://github.com/nationalarchives/tdr-terraform-backend/pull/82) into this repo.

Configuring it in the backend repository caused a problem whenever the Jenkins EC2 instance was redeployed, because the maintenance window is linked directly to the EC2 _instance_ ID. This meant that when you deploy the Jenkins EC2 instance, the backups fail because the maintenance windows tries to run the backups on the old instance.

Moving the configuration to the tdr-jenkins repo should fix the issue because we deploy a new EC2 instance by running the tdr-jenkins Terraform script. This should update link between the maintenance window and the EC2 instance whenever we deploy a new instance.

Only the Maintenance Window config has been moved into this repo, not the associated CloudWatch event and monitoring task. This is because the monitoring task, which should alert us via email and Slack, didn't work. We need to investigate the problem before moving it to this repo.

Also configure a specific AWS provider to avoid errors with more recent providers.