### PR TITLE
Pass EC2 instance ID instead of name to maintenance window module

### DIFF
--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -174,9 +174,9 @@ module "jenkins_build_postgres_execution_role" {
 
 # Configure Jenkins backup using Systems Manager Maintenance Windows
 module "jenkins_backup_maintenance_window" {
-  source        = "./tdr-terraform-modules/ssm_maintenance_window"
-  command       = "docker exec $(docker ps -aq -f ancestor=${module.ecr_jenkins_repository.repository.repository_url}) /opt/backup.sh ${data.aws_ssm_parameter.jenkins_backup_healthcheck_url.value}"
-  instance_name = local.ec2_instance_name
-  name          = "tdr-jenkins-backup-window"
-  schedule      = "cron(0 0 18 ? * MON-FRI *)"
+  source          = "./tdr-terraform-modules/ssm_maintenance_window"
+  command         = "docker exec $(docker ps -aq -f ancestor=${module.ecr_jenkins_repository.repository.repository_url}) /opt/backup.sh ${data.aws_ssm_parameter.jenkins_backup_healthcheck_url.value}"
+  ec2_instance_id = module.jenkins.instance_id
+  name            = "tdr-jenkins-backup-window"
+  schedule        = "cron(0 0 18 ? * MON-FRI *)"
 }


### PR DESCRIPTION
This forces the module to wait for the EC2 instance to be created, which means the maintenance task is run on the latest version of the instance.

This fixes a bug where the EC2 instance was updated, but Terraform couldn't tell that the instance ID needed to be updated to match.

Depends on https://github.com/nationalarchives/tdr-terraform-modules/pull/71 being merged.