### PR TITLE
Replace Docker Hub instructions with ECR

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ into ECR as above, then run:
 
 #### Add a new container
 
-The docker container must start with `FROM jenkins/jnlp-slave` This image is mostly stock ubuntu and from there, you need to install whatever it is you need for your build. Build the docker image and push to ECR.
+The docker container must start with `FROM jenkins/jnlp-slave:alpine` This image is mostly stock Alpine Linux and from there, you need to install whatever it is you need for your build. Build the docker image and push to ECR.
 
- You then need to configure another container in the clouds section of the jenkins [configuration](docker/jenkins.yml) You can copy and paste most of it, just change the name and the image.
+You then need to configure another container in the clouds section of the jenkins [configuration](docker/jenkins.yml) You can copy and paste most of it, just change the name and the image.
 
- Rebuild and push the jenkins docker container and redeploy to ECS. You can then use this container in your builds.
+Rebuild and push the jenkins docker container and redeploy to ECS. You can then use this container in your builds.
 
 ## Backups
 


### PR DESCRIPTION
Explain how to deploy Jenkins to ECR, since we have migrated all our Docker images to there.

Also add a note reminding people to restart the ECS service after pushing a new image, and update the default base image for Docker nodes in the Readme.