### PR TITLE
Add accounts to the frontend container

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -62,6 +62,10 @@ jenkins:
         environments:
         - name: "TDR_IDENTITY_POOL_ID"
           value: "${/mgmt/identitypoolid_intg}"
+        - name: "INTG_ACCOUNT"
+          value: "${/mgmt/intg_account}"
+        - name: "STAGING_ACCOUNT"
+          value: "${/mgmt/staging_account}"
         executionRole: "arn:aws:iam::${/mgmt/management_account}:role/TDRJenkinsBuildTransferFrontendExecutionRole"
         label: "transfer-frontend"
         launchType: "FARGATE"

--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -62,9 +62,9 @@ jenkins:
         environments:
         - name: "TDR_IDENTITY_POOL_ID"
           value: "${/mgmt/identitypoolid_intg}"
-        - name: "INTG_ACCOUNT"
+        - name: "INTG_AWS_ACCOUNT_NUMBER"
           value: "${/mgmt/intg_account}"
-        - name: "STAGING_ACCOUNT"
+        - name: "STAGING_AWS_ACCOUNT_NUMBER"
           value: "${/mgmt/staging_account}"
         executionRole: "arn:aws:iam::${/mgmt/management_account}:role/TDRJenkinsBuildTransferFrontendExecutionRole"
         label: "transfer-frontend"


### PR DESCRIPTION
The e2e tests need to assume a role in the intg/staging accounts in
order to check the consignment export s3 bucket. The sts sdk uses the
arn for the role which means we need the account number. It's easiest to
get these from the environment variables so I've added them to the
container here.
