### PR TITLE
Allow Jenkins to assume export role

### DIFF
--- a/terraform/modules/jenkins/iam.tf
+++ b/terraform/modules/jenkins/iam.tf
@@ -68,6 +68,8 @@ data "aws_iam_policy_document" "jenkins_fargate_policy_document" {
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRScriptsTerraformRoleStaging",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRScriptsTerraformRoleProd",
       "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeLambdaRoleMgmt",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeS3ExportRoleIntg",
+      "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/TDRJenkinsNodeS3ExportRoleStaging",
       "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.current.account_id}:task-definition/*:*",
       "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.current.account_id}:cluster/${aws_ecs_cluster.jenkins_cluster.name}",
       "arn:aws:ecs:eu-west-2:${data.aws_caller_identity.current.account_id}:task/*",


### PR DESCRIPTION
This is the task role for jenkins. It needs permission to be able to
pass the consignment export role used by the e2e tests to the node
container.
