### PR TITLE
Add gnu tar

### DIFF
--- a/docker/transfer-frontend/Dockerfile
+++ b/docker/transfer-frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/jnlp-slave:alpine
 USER root
 ENV AWS_DEFAULT_REGION eu-west-2
 WORKDIR /opt
-RUN apk update && apk add curl chromium firefox-esr && \    
+RUN apk update && apk add curl chromium firefox-esr tar && \    
     curl -Ls https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz | tar --strip-components=1 -xzvf - && \    
     mv /opt/bin/* /usr/local/bin/ && \
     wget -q https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-x64.tar.xz && \    


### PR DESCRIPTION
We need gnu tar to run the tests for the consignment export as the
version that comes with alpine is missing a lot of features that we're
using. This adds it to the image.
