### PR TITLE
Change owner to user 1000 for /var/run/docker*

### DIFF
--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -6,7 +6,7 @@ resource "aws_instance" "jenkins" {
   vpc_security_group_ids = [aws_security_group.ec2_internal.id]
   private_ip             = "10.0.1.221"
   key_name               = "jenkins_key_pair"
-  user_data              = "#!/usr/bin/env bash\necho ECS_CLUSTER=${aws_ecs_cluster.jenkins_cluster.name} > /etc/ecs/ecs.config"
+  user_data              = "#!/usr/bin/env bash\necho ECS_CLUSTER=${aws_ecs_cluster.jenkins_cluster.name} > /etc/ecs/ecs.config\nchown 1000:1000 /var/run/docker*"
   tags = merge(
     var.common_tags,
     map(


### PR DESCRIPTION
The jenkins docker container is now running as the jenkins user rather than root. This user is in the docker group but it's still not able to run docker commands. I think this is because the /var/run/docker.sock and /var/run/docker/ are owned by root on the host machine so the docker container can't access them. This changes permissions on the docker.sock and docker directory which allows the jenkins user to access them.
