### PR TITLE
Update base image of build nodes

### DIFF
--- a/docker/aws/Dockerfile
+++ b/docker/aws/Dockerfile
@@ -1,6 +1,6 @@
-FROM jenkins/jnlp-slave:alpine
+FROM jenkins/inbound-agent:alpine
 USER root
-RUN apk update \    
+RUN apk update \
     && apk add curl wget py3-pip gcc python3-dev musl-dev libffi-dev openssl-dev jansson-dev build-base libc-dev file-dev automake autoconf libtool flex bison \
     && pip3 install boto3 \
     && pip3 install awscli \

--- a/docker/npm/Dockerfile
+++ b/docker/npm/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jnlp-slave:alpine
+FROM jenkins/inbound-agent:alpine
 USER root
 RUN apk update && apk add curl python3 make && wget -q https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-x64.tar.xz && \
                     tar -xf node-v12.13.1-linux-x64.tar.xz --directory /usr/local --strip-components 1

--- a/docker/sbt/Dockerfile
+++ b/docker/sbt/Dockerfile
@@ -1,5 +1,5 @@
-FROM jenkins/jnlp-slave:alpine
-USER root 
+FROM jenkins/inbound-agent:alpine
+USER root
 WORKDIR /opt
 RUN apk update && apk add curl postgresql && \
     curl -Ls https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz | tar --strip-components=1 -xzvf - && \

--- a/docker/terraform/Dockerfile
+++ b/docker/terraform/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jnlp-slave:alpine
+FROM jenkins/inbound-agent:alpine
 USER root
 ENV AWS_DEFAULT_REGION eu-west-2
 RUN apk update && \

--- a/docker/transfer-frontend/Dockerfile
+++ b/docker/transfer-frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jnlp-slave:alpine
+FROM jenkins/inbound-agent:alpine
 USER root
 ENV AWS_DEFAULT_REGION eu-west-2
 WORKDIR /opt


### PR DESCRIPTION
The jenkins/jnlp-slave image has been deprecated and replaced by jenkins/inbound-agent. See https://github.com/jenkinsci/docker-inbound-agent

The latest version of both images was published two months ago, so they might be identical at the moment anyway.