### PR TITLE
Upgrade OpenSSL in the npm build node

### DIFF
--- a/docker/npm/Dockerfile
+++ b/docker/npm/Dockerfile
@@ -1,6 +1,7 @@
 FROM jenkins/inbound-agent:alpine
 USER root
 RUN apk update && apk add curl python3 make && wget -q https://nodejs.org/dist/v12.13.1/node-v12.13.1-linux-x64.tar.xz && \
-                    tar -xf node-v12.13.1-linux-x64.tar.xz --directory /usr/local --strip-components 1
+                    tar -xf node-v12.13.1-linux-x64.tar.xz --directory /usr/local --strip-components 1 && \
+                    apk upgrade openssl
 
 USER jenkins


### PR DESCRIPTION
The version in the Jenkins base image is out-of-date.