### PR TITLE
Upgrade musl

### DIFF
--- a/docker/sbt/Dockerfile
+++ b/docker/sbt/Dockerfile
@@ -2,6 +2,7 @@ FROM jenkins/inbound-agent:alpine
 USER root
 WORKDIR /opt
 RUN apk update && apk add curl postgresql && \
+    apk upgrade musl && \
     curl -Ls https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz | tar --strip-components=1 -xzvf - && \
     ln /opt/bin/sbt /usr/local/bin/sbt && ln /opt/bin/sbt-launch.jar /usr/local/bin/sbt-launch.jar
 USER jenkins


### PR DESCRIPTION
There is a security vulnerability on the version on the jenkins base
image. This will be fixed by jenkins eventually but for now, we'll
upgrade it manually.
