### PR TITLE
Remove Python build node image repository

### DIFF
--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -144,20 +144,6 @@ module "jenkins_build_transfer_frontend_execution_role" {
   repository_arn = module.ecr_jenkins_build_transfer_frontend_repository.repository.arn
 }
 
-module "ecr_jenkins_build_python_repository" {
-  source           = "./tdr-terraform-modules/ecr"
-  name             = "jenkins-build-python"
-  common_tags      = local.common_tags
-  policy_name      = "jenkins_policy"
-  policy_variables = { role_arn = module.jenkins_build_python_execution_role.role_arn }
-}
-
-module "jenkins_build_python_execution_role" {
-  source         = "./modules/build-role"
-  name           = "python"
-  repository_arn = module.ecr_jenkins_build_python_repository.repository.arn
-}
-
 module "ecr_jenkins_build_postgres_repository" {
   source           = "./tdr-terraform-modules/ecr"
   name             = "jenkins-build-postgres"


### PR DESCRIPTION
This Jenkins node image is no longer used. It was necessary when the latest version of Python 3 was unavailable in the Jenkins node base image, but that was updated recently so this ECR repo is no longer necessary.