### PR TITLE
Add the maintenance cloudwatch event.

### DIFF
--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -173,3 +173,12 @@ module "jenkins_backup_maintenance_window" {
   schedule        = "cron(0 0 18 ? * MON-FRI *)"
   common_tags     = local.common_tags
 }
+
+module "jenkins_maintenance_window_event" {
+  source                  = "./tdr-terraform-modules/cloudwatch_events"
+  event_pattern           = "jenkins_maintenance_event_window"
+  lambda_event_target_arn = list(data.aws_lambda_function.notifications_function.arn)
+  rule_name               = "jenkins-backup-maintenance-window"
+  rule_description        = "Capture failed runs of the jenkins backup"
+  event_variables         = { window_id = module.jenkins_backup_maintenance_window.window_id }
+}

--- a/terraform/root_data.tf
+++ b/terraform/root_data.tf
@@ -16,3 +16,7 @@ data "aws_ami" "ecs_ami" {
 data "aws_ssm_parameter" "jenkins_backup_healthcheck_url" {
   name = "/mgmt/jenkins/backup/healthcheck/url"
 }
+
+data "aws_lambda_function" "notifications_function" {
+  function_name = "tdr-notifications-mgmt"
+}


### PR DESCRIPTION
This was originally in the terraform-backend project but it's been moved here so that the instance id will update when we rebuild the jenkins ec2 instance.
