### PR TITLE
Install rust to the aws docker image

### DIFF
--- a/docker/aws/Dockerfile
+++ b/docker/aws/Dockerfile
@@ -14,3 +14,5 @@ COPY *.py /
 
 RUN chown jenkins /*.py
 USER jenkins
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/jenkins/.cargo/bin/:${PATH}"


### PR DESCRIPTION
The antivirus build uses this image and the latest version of the cryptography library that is uses needs rust installed.
