### PR TITLE
Move git secrets config to entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,12 +10,8 @@ RUN apk update && \
         pip3 install awscli && \
         mkdir -p /var/jenkins_home/init.groovy.d && \
         git clone https://github.com/awslabs/git-secrets.git && \
-        make install -C git-secrets && \
-        git-secrets --register-aws --global && \
-#       Additional git secrets rule to check for AWS account numbers (any set of 12 digits)
-        git-secrets --add --global '([^0-9])*[0-9]{12}([^0-9])*' && \
-#       Additional git secrets exclusion rule to allow dummy AWS account number 1234 for documentation
-        git-secrets --add --global --allowed '1234'
+        make install -C git-secrets
+
 
 ENV CASC_JENKINS_CONFIG /usr/share/jenkins/ref/jenkins.yaml
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,4 +5,7 @@ FILENAME=$(aws s3 ls s3://tdr-jenkins-backup-mgmt | awk '{print $4}' | sort -r |
 aws s3 cp s3://tdr-jenkins-backup-mgmt/"$FILENAME" /var/jenkins_home/jenkins-backup.tar.gz
 tar xzf /var/jenkins_home/jenkins-backup.tar.gz -C /var/jenkins_home
 rm -f /var/jenkins_home/jenkins-backup.tar.gz
+git-secrets --register-aws --global
+git-secrets --add --global '([^0-9])*[0-9]{12}([^0-9])*'
+git-secrets --add --global --allowed '1234'
 /sbin/tini -- /usr/local/bin/jenkins.sh


### PR DESCRIPTION
If it's configured in the build as it was, the global ~/.gitconfig file is not created for some reason I don't know. If we move these commands to the entrypoint script, it works and creates the correct file.
