### PR TITLE
Add missing script approval

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -242,3 +242,4 @@ security:
     approvedSignatures:
       - method org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper getRawBuild
       - staticMethod hudson.model.Hudson getInstance 
+      - method hudson.model.Run getEnvironment 


### PR DESCRIPTION
I missed a script approval for the e2e tests check to work, I've added it in here.
