### PR TITLE
Jenkins disk space fixes

### DIFF
--- a/docker/backup.sh
+++ b/docker/backup.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
 curl $1/start
-tar -zcf /var/jenkins_home/jenkins-backup.tar.gz -C /var/jenkins_home jobs
-aws s3 cp /var/jenkins_home/jenkins-backup.tar.gz s3://tdr-jenkins-backup-mgmt/jenkins-backup-`date +"%Y-%m-%d:%H:%M"`.tar.gz
-rm -f /var/jenkins_home/jenkins-backup.tar.gz
+tar -zcf - -C /var/jenkins_home jobs | aws s3 cp - s3://tdr-jenkins-backup-mgmt/jenkins-backup-`date +"%Y-%m-%d:%H:%M"`.tar.gz
 curl $1
-

--- a/terraform/modules/jenkins/ec2.tf
+++ b/terraform/modules/jenkins/ec2.tf
@@ -7,6 +7,9 @@ resource "aws_instance" "jenkins" {
   private_ip             = "10.0.1.221"
   key_name               = "jenkins_key_pair"
   user_data              = "#!/usr/bin/env bash\necho ECS_CLUSTER=${aws_ecs_cluster.jenkins_cluster.name} > /etc/ecs/ecs.config\nchown 1000:1000 /var/run/docker*"
+  root_block_device {
+    volume_size = 60
+  }
   tags = merge(
     var.common_tags,
     map(


### PR DESCRIPTION
- Stream backup file straight to s3
- Give the jenkins box 60Gb disk
