### PR TITLE
Add line to upgrade openssl

### DIFF
--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/inbound-agent:alpine
 USER root
 WORKDIR /opt
 RUN apk update && apk add curl postgresql && \
-    apk upgrade musl && \
+    apk upgrade musl openssl && \
     curl -Ls https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz | tar --strip-components=1 -xzvf - && \
     ln /opt/bin/sbt /usr/local/bin/sbt && ln /opt/bin/sbt-launch.jar /usr/local/bin/sbt-launch.jar
 USER jenkins


### PR DESCRIPTION
This will fix a current vulnerability but also this is a common source of vulnerabilities so it makes sense to have it in the dockerfile and we can fix it by running the docker build again.
