### PR TITLE
Rename jenkins node task definition

### DIFF
--- a/terraform/modules/jenkins/templates/s3publish.json.tpl
+++ b/terraform/modules/jenkins/templates/s3publish.json.tpl
@@ -3,7 +3,7 @@
       "cpu": 1024,
       "memory": 4096,
       "image": "${account}.dkr.ecr.eu-west-2.amazonaws.com/jenkins-build-postgres",
-      "name": "sonatype",
+      "name": "sbtwithpostgres",
       "taskRoleArn": "arn:aws:iam::${account}:role/TDRJenkinsPublishRole",
       "compatibilities": ["FARGATE"],
       "networkMode": "awsvpc"

--- a/terraform/modules/sbt-with-postgres-task/ecs.tf
+++ b/terraform/modules/sbt-with-postgres-task/ecs.tf
@@ -1,6 +1,6 @@
 data "aws_caller_identity" "current" {}
 
-data "template_file" "s3_publish_template" {
+data "template_file" "sbt_with_postgres_template" {
   template = file("./modules/jenkins/templates/s3publish.json.tpl")
 
   vars = {
@@ -8,9 +8,9 @@ data "template_file" "s3_publish_template" {
   }
 }
 
-resource "aws_ecs_task_definition" "s3_publish_task" {
-  container_definitions    = data.template_file.s3_publish_template.rendered
-  family                   = "s3publish"
+resource "aws_ecs_task_definition" "sbt_with_postgres_task" {
+  container_definitions    = data.template_file.sbt_with_postgres_template.rendered
+  family                   = "sbtwithpostgres"
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
   cpu                      = "2048"

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -76,8 +76,8 @@ module "jenkins_backup_s3" {
   common_tags = local.common_tags
 }
 
-module "s3_publish" {
-  source = "./modules/s3-publish-build-task"
+module "sbt_with_postgres" {
+  source = "./modules/sbt-with-postgres-task"
 }
 
 module "ecr_jenkins_repository" {


### PR DESCRIPTION
This was called s3Publish but now I want to use it for the database user creation lambda tests so I've renamed it to something a bit more generic.
