### PR TITLE
Remove Jenkins admin permissions from dev team

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -46,7 +46,23 @@ jenkins:
   authorizationStrategy:
     globalMatrix:
       permissions:
-        - "Overall/Administer:nationalarchives*transfer-digital-records"
+      # Give admin permissions to TDR admin team
+      - "Overall/Administer:nationalarchives*transfer-digital-records-admins"
+      # Allow TDR dev team to create jobs and run them
+      - "Agent/Build:nationalarchives*transfer-digital-records"
+      - "Job/Build:nationalarchives*transfer-digital-records"
+      - "Job/Cancel:nationalarchives*transfer-digital-records"
+      - "Job/Configure:nationalarchives*transfer-digital-records"
+      - "Job/Create:nationalarchives*transfer-digital-records"
+      - "Job/Discover:nationalarchives*transfer-digital-records"
+      - "Job/Read:nationalarchives*transfer-digital-records"
+      - "Lockable Resources/View:nationalarchives*transfer-digital-records"
+      - "Overall/Read:nationalarchives*transfer-digital-records"
+      - "Run/Update:nationalarchives*transfer-digital-records"
+      - "SCM/Tag:nationalarchives*transfer-digital-records"
+      - "View/Configure:nationalarchives*transfer-digital-records"
+      - "View/Create:nationalarchives*transfer-digital-records"
+      - "View/Read:nationalarchives*transfer-digital-records"
   clouds:
   - ecs:
       allowedOverrides: "all"


### PR DESCRIPTION
Allow members of the TDR admin team to manage Jenkins, but remove those permissions from the main dev team.

This still allows devs to deploy to all environments, which we might revisit in another change.

This draft PR while we test the changes.