### PR TITLE
Fetch IP allow list from tdr-configurations instead of SSM param

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .DS_Store
 # modules
 tdr-terraform-modules
+tdr-configurations
 target

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This creates the jenkins docker image which we run as part of the ECS service. I
 
 Each folder within the docker directory builds a Jenkins node image which is used to build some part of our infrastructure. The aws directory contains some python scripts which are used by the builds. Using python scripts makes assuming a role in the sub accounts easier than using the cli.
 
-### terraform
+### Terraform
+
 This creates
 * The EC2 instance for the master to run on
 * The VPC and subnets
@@ -21,14 +22,11 @@ This creates
 * The security group
 * The AWS SSM parameters
 
-### terraform modules
-* Certain terraform modules are in the tdr-terraform-modules repository
-```
-cd terraform
-git clone git@github.com:nationalarchives/tdr-terraform-modules.git
-```
+#### Terraform modules
 
-### terraform task modules
+Some terraform modules are in the shared tdr-terraform-modules repository. See the deployment section below.
+
+#### Terraform task modules
 Some builds need a task definition with more than one container. These are defined here and then used within the Jenkins pipeline file.
 
 ## Sample job
@@ -123,6 +121,22 @@ EC2 instance, manually stop the current Jenkins ECS task in the AWS console. ECS
 will automatically deploy a new container when the first one has stopped.
 
 ### Deploy Jenkins EC2 instance and Terraform config
+
+#### Set up sub-projects
+
+Clone the Terraform modules and the configurations project, which contains
+sensitive information like IP addresses:
+
+```bash
+cd terraform
+git clone git@github.com:nationalarchives/tdr-terraform-modules.git
+git clone git@github.com:nationalarchives/tdr-configurations.git
+```
+
+If these subfolders already exist, pull the latest version of the master branch
+for each one.
+
+#### Run Terraform
 
 ```bash
 cd terraform

--- a/terraform/modules/jenkins/security.tf
+++ b/terraform/modules/jenkins/security.tf
@@ -33,10 +33,6 @@ resource "aws_security_group" "ec2_internal" {
   }
 }
 
-data "aws_ssm_parameter" "external_ips" {
-  name = "/${var.environment}/external_ips"
-}
-
 resource "aws_security_group" "jenkins_alb_group" {
   name        = "${var.app_name}-alb-security-group"
   description = "Controls access to the Jenkins load balancer"
@@ -45,14 +41,14 @@ resource "aws_security_group" "jenkins_alb_group" {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = split(",", data.aws_ssm_parameter.external_ips.value)
+    cidr_blocks = var.ip_allowlist
   }
 
   ingress {
     protocol    = "tcp"
     from_port   = 80
     to_port     = 80
-    cidr_blocks = split(",", data.aws_ssm_parameter.external_ips.value)
+    cidr_blocks = var.ip_allowlist
   }
 
   egress {
@@ -80,4 +76,3 @@ resource "aws_security_group" "ecs_tasks" {
     map("Name", "${var.environment}-ecs-task-security-group")
   )
 }
-

--- a/terraform/modules/jenkins/variables.tf
+++ b/terraform/modules/jenkins/variables.tf
@@ -24,6 +24,10 @@ variable "encrypted_ami_id" {}
 
 variable "environment" {}
 
+variable "ip_allowlist" {
+  type = list
+}
+
 variable "jenkins_log_bucket" {}
 
 variable "repository" {}

--- a/terraform/root.tf
+++ b/terraform/root.tf
@@ -1,3 +1,7 @@
+module "global_parameters" {
+  source = "./tdr-configurations/terraform"
+}
+
 module "encryption_key" {
   source      = "./tdr-terraform-modules/kms"
   project     = var.project
@@ -31,6 +35,7 @@ module "jenkins" {
   ec2_instance_name   = local.ec2_instance_name
   encrypted_ami_id    = module.jenkins_ami.encrypted_ami_id
   environment         = local.environment
+  ip_allowlist        = local.ip_allowlist
   jenkins_log_bucket  = module.jenkins_logs_s3.s3_bucket_id
   repository          = module.ecr_jenkins_repository.repository
 }

--- a/terraform/root_locals.tf
+++ b/terraform/root_locals.tf
@@ -9,4 +9,8 @@ locals {
     "CostCentre", data.aws_ssm_parameter.cost_centre.value
   )
   ec2_instance_name = "jenkins-task-definition-${local.environment}"
+
+  developer_ip_list = split(",", module.global_parameters.developer_ips)
+  trusted_ip_list   = split(",", module.global_parameters.trusted_ips)
+  ip_allowlist      = concat(local.developer_ip_list, local.trusted_ip_list)
 }


### PR DESCRIPTION
This changes where the list of IPs which are allowed to access Jenkins is read from.

Before, we read the list from a parameter in the AWS SSM Parameter Store. Now, it reads the list from the [tdr-configurations](https://github.com/nationalarchives/tdr-configurations) repo.

The tdr-configurations repo was already being used for the frontend load balancer allow list, so this change makes Jenkins consistent with [tdr-terraform-environments](https://github.com/nationalarchives/tdr-terraform-environments).

It also reduces the number of deployment steps. When the list changes, we can now deploy the changes by running this Terraform project, without having to deploy the change to the parameter store first.