### PR TITLE
Remove pen test team from permissions list

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -48,8 +48,6 @@ jenkins:
       permissions:
       # Give admin permissions to TDR admin team
       - "Overall/Administer:nationalarchives*transfer-digital-records-admins"
-      # Give temporary admin permissions to pen testing team
-      - "Overall/Administer:nationalarchives*tdr-security-check"
       # Allow TDR dev team to create jobs and run them
       - "Agent/Build:nationalarchives*transfer-digital-records"
       - "Job/Build:nationalarchives*transfer-digital-records"


### PR DESCRIPTION
The GitHub team has been deleted, so this is no longer necessary.