### PR TITLE
Move STAGING_AWS_ACCOUNT_NUMBER variable.

### DIFF
--- a/docker/jenkins-prod.yml
+++ b/docker/jenkins-prod.yml
@@ -59,6 +59,9 @@ jenkins:
       templates:
       - assignPublicIp: true
         cpu: 2048
+        environments:
+        - name: "STAGING_AWS_ACCOUNT_NUMBER"
+          value: "${/mgmt/staging_account}"
         image: "${/mgmt/management_account}.dkr.ecr.eu-west-2.amazonaws.com/jenkins-build-transfer-frontend"
         executionRole: "arn:aws:iam::${/mgmt/management_account}:role/TDRJenkinsBuildTransferFrontendExecutionRole"
         label: "transfer-frontend"

--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -80,8 +80,6 @@ jenkins:
           value: "${/mgmt/identitypoolid_intg}"
         - name: "INTG_AWS_ACCOUNT_NUMBER"
           value: "${/mgmt/intg_account}"
-        - name: "STAGING_AWS_ACCOUNT_NUMBER"
-          value: "${/mgmt/staging_account}"
         executionRole: "arn:aws:iam::${/mgmt/management_account}:role/TDRJenkinsBuildTransferFrontendExecutionRole"
         label: "transfer-frontend"
         launchType: "FARGATE"


### PR DESCRIPTION
This is needed for prod jenkins which runs the acceptance tests for
staging but isn't needed in integration jenkins so I've swapped them
over.
