### PR TITLE
This plugin adds the strict-transport-security header

### DIFF
--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -30,6 +30,7 @@ github:1.33.1
 github-api:1.123
 github-branch-source:2.10.4
 handlebars:3.0.8
+hsts-filter-plugin:1.0
 jackson2-api:2.12.3
 jdk-tool:1.5
 jjwt-api:0.11.2-9.c8b45b8bb173


### PR DESCRIPTION
The pen test found that this was missing, this plugin adds it back in
