### PR TITLE
Distinguish between jenkins and jenkins-prod in backup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,12 @@ To manually initiate a backup:
   a new EC2 instance:
   - Go the [Systems Manager Command History]
   - Find a recent successful backup
-  - Select the backup and click Rerun
+  - Open the command details and check the parameters to make sure it is for the
+    Jenkins instance you want to back up. The `docker exec` command will be
+    `<account>.dkr.ecr.eu-west-2.amazonaws.com/jenkins` for integration Jenkins,
+    and `<account>.dkr.ecr.eu-west-2.amazonaws.com/jenkins-prod` for  production
+    Jenkins.
+  - At the top of the command details page, click the Rerun button
 - Otherwise:
   - Go to the [Maintenance Window config][mw-config] and click Edit
   - Change the schedule so that it will run in a few minutes time. For example,


### PR DESCRIPTION
The recent backup history is a single list which combines both Jenkins instances, so you have to open individual commands to make sure you're rerunning a backup of the intended instance.