### PR TITLE
Add secret for slack release channel webhook.

### DIFF
--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -28,6 +28,10 @@ credentials:
           scope: GLOBAL
           secret: ${/mgmt/pr_monitor/slack/webhook}
       - string:
+          id: "slack-release-channel"
+          scope: GLOBAL
+          secret: ${/mgmt/release/slack/webhook}
+      - string:
           id: "npm-login"
           scope: GLOBAL
           secret: ${/mgmt/npm_token}


### PR DESCRIPTION
I'm using a slack webhook to send updates about out of date versions and
we would like to send this to the release channel. We don't currently
have a webhook for the release channel. I've added the parameter into
SSM manually and this will add it into the Jenkins instance.

We don't need this for prod Jenkins as the job will only run on the
integration Jenkins.
