### PR TITLE
Pin dependencies for awscli and boto3

### DIFF
--- a/docker/aws/Dockerfile
+++ b/docker/aws/Dockerfile
@@ -3,9 +3,9 @@ USER root
 RUN apk update \
     && apk add curl wget py3-pip gcc python3-dev musl-dev libffi-dev openssl-dev jansson-dev build-base libc-dev file-dev automake autoconf libtool flex bison \
     && apk upgrade openssl \
-    && pip3 install boto3 \
-    && pip3 install awscli \
-    && pip3 install c7n c7n-mailer c7n-guardian \
+    && pip3 install boto3==1.17.96 \
+    && pip3 install awscli==1.19.96 \
+    && pip3 install c7n c7n-mailer c7n-guardian --ignore-installed six \
     && pip3 install ruamel.yaml \
     && ln /usr/bin/python3 /usr/bin/python \
     && wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq \


### PR DESCRIPTION
The version of botocore which the c7n dependencies need is older than
the ones used by awscli and boto3 and they're incompatible so we need to
do this while cloud custodian upgrade their dependencies.
