### PR TITLE
Install xz

### DIFF
--- a/docker/transfer-frontend/Dockerfile
+++ b/docker/transfer-frontend/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/inbound-agent:alpine
 USER root
 ENV AWS_DEFAULT_REGION eu-west-2
 WORKDIR /opt
-RUN apk update && apk add curl chromium firefox-esr tar && \
+RUN apk update && apk add curl chromium firefox-esr tar xz && \
     apk upgrade openssl && \
     apk upgrade libxml2 && \
     curl -Ls https://github.com/sbt/sbt/releases/download/v1.4.1/sbt-1.4.1.tgz | tar --strip-components=1 -xzvf - && \


### PR DESCRIPTION
One of the latest updates to alpine seems to have removed the xz install
by default so when you try to do `tar -xz` it fails. Adding this lets
you build the docker image.
