### PR TITLE
Upgrade main terraform image to v13

### DIFF
--- a/docker/terraform/Dockerfile
+++ b/docker/terraform/Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && \
 	apk add py3-pip wget unzip curl && \
         pip3 install awscli && \
 	apk upgrade openssl && \
-	wget https://releases.hashicorp.com/terraform/0.12.28/terraform_0.12.28_linux_amd64.zip && \
+	wget https://releases.hashicorp.com/terraform/0.13.7/terraform_0.13.7_linux_amd64.zip && \
 	unzip terraform_0.12.28_linux_amd64.zip && \
 	mv terraform /usr/bin && \
 	terraform --version


### PR DESCRIPTION
The terraform-v13 image node will be retained until all Jenkins jobs are pointed back to the main terraform image node

Draft until `tna-custodian` repo upgraded.