### PR TITLE
Return status instead of stdout

### DIFF
--- a/docker/plugin-updates/Jenkinsfile
+++ b/docker/plugin-updates/Jenkinsfile
@@ -15,8 +15,8 @@ pipeline {
           def branch = "plugin-updates-${versionTag}"
           checkout scm
           sh 'plugin-updates'
-          def diffExitCode = sh(script: "git diff --exit-code docker/plugins.txt", returnStdout: true).trim()
-          if(diffExitCode == "1") {
+          def diffExitCode = sh(script: "git diff --exit-code docker/plugins.txt", returnStatus: true)
+          if(diffExitCode == 1) {
             sh 'git status'
             sh "git checkout -b ${branch}"
             sh 'git add docker/plugins.txt'


### PR DESCRIPTION
The job was failing if there were changes because the command returns
status code 1. Using returnStatus means the job will report the exit
code without failing.
