### PR TITLE
Copy from the plugin-updates directory.

### DIFF
--- a/docker/nodes/plugin-updates/Dockerfile
+++ b/docker/nodes/plugin-updates/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk upgrade musl openssl apk-tools && apk add bash curl gnupg 
               curl -Ls https://github.com/cli/cli/releases/download/v1.6.2/gh_1.6.2_linux_amd64.tar.gz |  tar --strip-components=1 -xzvf - && \
               mv bin/gh /usr/local/bin
 WORKDIR /opt/plugin-updates
-COPY ./ .
+COPY plugin-updates/ .
 RUN sbt universal:packageZipTarball && \
               tar -xzf target/universal/tdr-plugin-updates.tgz && \
               cp tdr-plugin-updates/bin/* /usr/bin/ && \


### PR DESCRIPTION
We have changed the build process so we build all of the node images
from the nodes directory and use `-f <node_name>/Dockerfile` in the
build command. This copy command was copying the contents of the nodes
directory instead of the plugin-updates directory it was supposed to so
this corrects it.
