### PR TITLE
Use aws cli version 2

### DIFF
--- a/docker/nodes/aws/Dockerfile
+++ b/docker/nodes/aws/Dockerfile
@@ -1,17 +1,19 @@
 FROM jenkins/inbound-agent:alpine
 USER root
 RUN apk update \
-    && apk add curl wget py3-pip gcc python3-dev musl-dev libffi-dev openssl-dev jansson-dev build-base libc-dev file-dev automake autoconf libtool flex bison \
+    && apk add curl wget py3-pip gcc python3-dev musl-dev libffi-dev openssl-dev jansson-dev build-base libc-dev file-dev automake autoconf libtool flex bison unzip \
     && apk upgrade openssl \
     && apk upgrade apk-tools \
-    && pip3 install boto3==1.17.96 \
-    && pip3 install awscli==1.19.96 \
+    && pip3 install boto3 \
     && pip3 install c7n c7n-mailer c7n-guardian --ignore-installed six \
     && pip3 install ruamel.yaml \
     && ln /usr/bin/python3 /usr/bin/python \
-    && wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq \
-    && chmod +x /usr/local/bin/jq
-COPY *.py /
+    && wget -q https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O /usr/local/bin/jq \
+    && chmod +x /usr/local/bin/jq \
+    && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+    && unzip -qq awscliv2.zip \
+    && ./aws/install
+COPY aws/*.py /
 
 RUN chown jenkins /*.py
 USER jenkins


### PR DESCRIPTION
There are dependency problems between aws cli v1 and the other
dependencies that use botocore.

It seems the easiest is to install aws cli v2. I've looked at the places
we're using it and tried out a couple of builds that use it and it looks
ok.
