### PR TITLE
Tag Jenkins node images with version number

### DIFF
--- a/Jenkinsfile-build-nodes
+++ b/Jenkinsfile-build-nodes
@@ -1,11 +1,13 @@
 library("tdr-jenkinslib")
 
+def version = "v${env.BUILD_NUMBER}"
+def isSandboxEcr = params.ECR_REPOSITORY == "sandbox"
 def isJenkinsParentNode = (params.JENKINS_NODE == "jenkins" || params.JENKINS_NODE == "jenkins-prod")
-def account = params.ECR_REPOSITORY == "sandbox" ? "${env.SANDBOX_ACCOUNT}" : "${env.MANAGEMENT_ACCOUNT}"
+def account = isSandboxEcr ? "${env.SANDBOX_ACCOUNT}" : "${env.MANAGEMENT_ACCOUNT}"
 def imageName = isJenkinsParentNode ? "${params.JENKINS_NODE}" : "jenkins-build-${params.JENKINS_NODE}"
 def ecrRoot = "${account}.dkr.ecr.eu-west-2.amazonaws.com"
-def imageTag = params.ECR_REPOSITORY == "sandbox" ? "${ecrRoot}/sandbox_ecr_repository:${imageName}"
-        : "${ecrRoot}/${imageName}:latest"
+def imageTag = isSandboxEcr ? "${ecrRoot}/sandbox_ecr_repository:${imageName}"
+        : "${ecrRoot}/${imageName}:${version}"
 def dockerFileName = params.JENKINS_NODE == "jenkins-prod" ? "Dockerfile-prod" : "Dockerfile"
 
 pipeline {
@@ -50,6 +52,23 @@ pipeline {
           script {
             sh "aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${account}.dkr.ecr.eu-west-2.amazonaws.com"
             sh "docker push ${imageTag}"
+          }
+        }
+      }
+      stage('Post build') {
+        when {
+          expression { !isSandboxEcr }
+        }
+        //To avoid duplicate Docker image tag "jenkins-prod:latest" on the Jenkins prod instance tag the built image with version number
+        //Then retag as "latest" in ECR once the image has been pushed
+        stages {
+          stage('Tag image with "latest"') {
+            steps {
+              script {
+                def manifest = sh(script: "aws ecr batch-get-image --repository-name ${imageName} --image-ids imageTag=${version} --query 'images[].imageManifest' --output text", returnStdout: true).trim()
+                sh "aws ecr put-image --repository-name ${imageName} --image-tag latest --image-manifest '${manifest}'"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
To avoid having duplicate image tag of "jenkins-prod:latest" when building the Jenkins prod image node on the Jenkins prod instance, use version number as the tag, then retag the pushed image on ECR with the "latest".

Having a duplicate image tag causes Docker to untag the earlier image, ie the image which the Jenkins prod container is built from. This means that Jenkins prod container references the image id instead of the tag. This causes the Jenkins backup script to fail as the script looks for the container using the image tag, which is no longer referenced by the running container.