### PR TITLE
Pull latest JDK8 image

### DIFF
--- a/docker/nodes/postgres/Dockerfile
+++ b/docker/nodes/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:alpine
+FROM jenkins/inbound-agent:latest-alpine-jdk8
 USER root
 WORKDIR /opt
 RUN apk update && apk add curl postgresql gnupg && \


### PR DESCRIPTION
The latest jenkins/inbound-agent:alpine is causing an error with sbt. Appears to be related that the latest alpine is using Java 11 which is incompatible with sbt: https://github.com/sbt/sbt/issues/3804#issuecomment-761830689

Ensure use alpine with JDK8