### PR TITLE
Disk space alerts

### DIFF
--- a/terraform/root_common.tf
+++ b/terraform/root_common.tf
@@ -32,7 +32,7 @@ module "encryption_key" {
   function    = "encryption"
   environment = local.environment
   common_tags = local.common_tags
-  key_policy  = "message_system_access"
+  key_policy  = "cloudwatch"
 }
 
 module "jenkins_ami" {
@@ -155,4 +155,12 @@ module "jenkins_sign_commits_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "TDRJenkinsSignCommitsPolicy"
   policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_github_gpg_policy.json.tpl", { account_id = data.aws_caller_identity.current.account_id })
+}
+
+module "notifications_topic" {
+  source      = "./tdr-terraform-modules/sns"
+  common_tags = local.common_tags
+  function    = "notifications"
+  project     = var.project
+  kms_key_arn = module.encryption_key.kms_key_arn
 }

--- a/terraform/root_common.tf
+++ b/terraform/root_common.tf
@@ -164,3 +164,9 @@ module "notifications_topic" {
   project     = var.project
   kms_key_arn = module.encryption_key.kms_key_arn
 }
+
+module "jenkins_integration_cloudwatch_agent_policy" {
+  source        = "./tdr-terraform-modules/iam_policy"
+  name          = "TDRJenkinsCloudwatchAgentPolicyMgmt"
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_cloudwatch_agent_integration.json.tpl", {})
+}

--- a/terraform/root_common.tf
+++ b/terraform/root_common.tf
@@ -168,5 +168,5 @@ module "notifications_topic" {
 module "jenkins_cloudwatch_agent_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "TDRJenkinsCloudwatchAgentPolicyMgmt"
-  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_cloudwatch_agent_integration.json.tpl", {})
+  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_cloudwatch_agent.json.tpl", {})
 }

--- a/terraform/root_common.tf
+++ b/terraform/root_common.tf
@@ -165,7 +165,7 @@ module "notifications_topic" {
   kms_key_arn = module.encryption_key.kms_key_arn
 }
 
-module "jenkins_integration_cloudwatch_agent_policy" {
+module "jenkins_cloudwatch_agent_policy" {
   source        = "./tdr-terraform-modules/iam_policy"
   name          = "TDRJenkinsCloudwatchAgentPolicyMgmt"
   policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_cloudwatch_agent_integration.json.tpl", {})

--- a/terraform/root_integration.tf
+++ b/terraform/root_integration.tf
@@ -161,12 +161,6 @@ module "jenkins_integration_cloudwatch_ssm_parameter" {
   ]
 }
 
-module "jenkins_integration_cloudwatch_agent_policy" {
-  source        = "./tdr-terraform-modules/iam_policy"
-  name          = "TDRJenkinsCloudwatchAgentPolicyMgmt"
-  policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_cloudwatch_agent_integration.json.tpl", {})
-}
-
 module "jenkins_integration_disk_space_alarm" {
   source      = "./tdr-terraform-modules/cloudwatch_alarms"
   environment = local.environment
@@ -174,4 +168,7 @@ module "jenkins_integration_disk_space_alarm" {
   metric_name = "disk_used_percent"
   project     = var.project
   threshold   = 70
+  dimensions = {
+    server_name = "Jenkins"
+  }
 }

--- a/terraform/root_integration.tf
+++ b/terraform/root_integration.tf
@@ -162,13 +162,18 @@ module "jenkins_integration_cloudwatch_ssm_parameter" {
 }
 
 module "jenkins_integration_disk_space_alarm" {
-  source      = "./tdr-terraform-modules/cloudwatch_alarms"
-  environment = local.environment
-  function    = "jenkins-disk-space-alarm"
-  metric_name = "disk_used_percent"
-  project     = var.project
-  threshold   = 70
+  source             = "./tdr-terraform-modules/cloudwatch_alarms"
+  environment        = local.environment
+  function           = "jenkins-disk-space-alarm"
+  metric_name        = "disk_used_percent"
+  project            = var.project
+  threshold          = 70
+  notification_topic = module.notifications_topic.sns_arn
   dimensions = {
     server_name = "Jenkins"
+    host        = module.jenkins_integration_ec2.private_dns
+    device      = "xvda1"
+    fstype      = "ext4"
+    path        = "/"
   }
 }

--- a/terraform/root_integration.tf
+++ b/terraform/root_integration.tf
@@ -40,7 +40,7 @@ module "jenkins_integration_ec2" {
   attach_policies     = { ec2_policy = module.jenkins_ec2_policy.policy_arn, cloudwatch_agent_policy = module.jenkins_integration_cloudwatch_agent_policy.policy_arn }
   private_ip          = "10.0.1.221"
   user_data           = "user_data_jenkins_docker"
-  user_data_variables = { jenkins_cluster_name = "jenkins-${local.environment}" }
+  user_data_variables = { jenkins_cluster_name = "jenkins-${local.environment}", agent_policy_parameter_name = "/${local.environment}/cloudwatch/agent/integration/policy" }
   instance_type       = "t2.medium"
   volume_size         = 60
 }
@@ -157,7 +157,7 @@ module "jenkins_integration_cloudwatch_ssm_parameter" {
   source      = "./tdr-terraform-modules/ssm_parameter"
   common_tags = local.common_tags
   parameters = [
-    { name = "/${local.environment}/jenkins_cloudwatch_agent_config", description = "The configuration for Jenkins Cloudwatch Agent", type = "String", value = templatefile("./tdr-terraform-modules/ssm_parameter/templates/jenkins_cloudwatch_agent.json.tpl", { server_name = "Jenkins" }) }
+    { name = "/${local.environment}/cloudwatch/agent/integration/policy", description = "The configuration for Jenkins Cloudwatch Agent", type = "String", value = templatefile("./tdr-terraform-modules/ssm_parameter/templates/jenkins_cloudwatch_agent.json.tpl", { server_name = "Jenkins" }) }
   ]
 }
 

--- a/terraform/root_integration.tf
+++ b/terraform/root_integration.tf
@@ -37,7 +37,7 @@ module "jenkins_integration_ec2" {
   name                = local.ec2_instance_name
   subnet_id           = module.jenkins_vpc.private_subnets[1]
   security_group_id   = module.jenkins_ec2_security_group.security_group_id
-  attach_policies     = { ec2_policy = module.jenkins_ec2_policy.policy_arn, cloudwatch_agent_policy = module.jenkins_integration_cloudwatch_agent_policy.policy_arn }
+  attach_policies     = { ec2_policy = module.jenkins_ec2_policy.policy_arn, cloudwatch_agent_policy = module.jenkins_cloudwatch_agent_policy.policy_arn }
   private_ip          = "10.0.1.221"
   user_data           = "user_data_jenkins_docker"
   user_data_variables = { jenkins_cluster_name = "jenkins-${local.environment}", agent_policy_parameter_name = "/${local.environment}/cloudwatch/agent/integration/policy" }

--- a/terraform/root_locals.tf
+++ b/terraform/root_locals.tf
@@ -11,7 +11,7 @@ locals {
       "CostCentre"      = data.aws_ssm_parameter.cost_centre.value
     }
   )
-  ec2_instance_name = "JenkinsTaskDefinition"
+  ec2_instance_name = "Jenkins"
 
   developer_ip_list = split(",", module.global_parameters.developer_ips)
   trusted_ip_list   = split(",", module.global_parameters.trusted_ips)

--- a/terraform/root_production.tf
+++ b/terraform/root_production.tf
@@ -155,7 +155,7 @@ module "jenkins_ecs_execution_policy_prod" {
   policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_ecs_execution_prod.json.tpl", { account_id = data.aws_caller_identity.current.account_id })
 }
 
-module "jenkins_integration_cloudwatch_ssm_parameter" {
+module "jenkins_production_cloudwatch_ssm_parameter" {
   source      = "./tdr-terraform-modules/ssm_parameter"
   common_tags = local.common_tags
   parameters = [
@@ -163,7 +163,7 @@ module "jenkins_integration_cloudwatch_ssm_parameter" {
   ]
 }
 
-module "jenkins_integration_disk_space_alarm" {
+module "jenkins_production_disk_space_alarm" {
   source      = "./tdr-terraform-modules/cloudwatch_alarms"
   environment = local.environment
   function    = "jenkins-disk-space-alarm"

--- a/terraform/root_production.tf
+++ b/terraform/root_production.tf
@@ -166,7 +166,7 @@ module "jenkins_production_cloudwatch_ssm_parameter" {
 module "jenkins_production_disk_space_alarm" {
   source             = "./tdr-terraform-modules/cloudwatch_alarms"
   environment        = local.environment
-  function           = "jenkins-disk-space-alarm"
+  function           = "jenkins-prod-disk-space-alarm"
   metric_name        = "disk_used_percent"
   project            = var.project
   threshold          = 70

--- a/terraform/root_production.tf
+++ b/terraform/root_production.tf
@@ -154,3 +154,23 @@ module "jenkins_ecs_execution_policy_prod" {
   name          = "TDRJenkinsExecutionPolicyProdMgmt"
   policy_string = templatefile("./tdr-terraform-modules/iam_policy/templates/jenkins_ecs_execution_prod.json.tpl", { account_id = data.aws_caller_identity.current.account_id })
 }
+
+module "jenkins_integration_cloudwatch_ssm_parameter" {
+  source      = "./tdr-terraform-modules/ssm_parameter"
+  common_tags = local.common_tags
+  parameters = [
+    { name = "/${local.environment}/jenkins_cloudwatch_agent_config", description = "The configuration for Jenkins Cloudwatch Agent", type = "String", value = templatefile("./tdr-terraform-modules/ssm_parameter/templates/jenkins_cloudwatch_agent.json.tpl", { server_name = "JenkinsProd" }) }
+  ]
+}
+
+module "jenkins_integration_disk_space_alarm" {
+  source      = "./tdr-terraform-modules/cloudwatch_alarms"
+  environment = local.environment
+  function    = "jenkins-disk-space-alarm"
+  metric_name = "disk_used_percent"
+  project     = var.project
+  threshold   = 70
+  dimensions = {
+    server_name = "JenkinsProd"
+  }
+}

--- a/terraform/root_production.tf
+++ b/terraform/root_production.tf
@@ -173,5 +173,9 @@ module "jenkins_production_disk_space_alarm" {
   notification_topic = module.notifications_topic.sns_arn
   dimensions = {
     server_name = "JenkinsProd"
+    host        = module.jenkins_ec2_prod.private_dns
+    device      = "xvda1"
+    fstype      = "ext4"
+    path        = "/"
   }
 }

--- a/terraform/root_production.tf
+++ b/terraform/root_production.tf
@@ -37,7 +37,7 @@ module "jenkins_ec2_prod" {
   name                = "JenkinsProduction"
   subnet_id           = module.jenkins_vpc.private_subnets[1]
   security_group_id   = module.jenkins_ec2_security_group.security_group_id
-  attach_policies     = { ec2_policy = module.jenkins_ec2_policy.policy_arn, cloudwatch_agent_policy = module.jenkins_integration_cloudwatch_agent_policy.policy_arn }
+  attach_policies     = { ec2_policy = module.jenkins_ec2_policy.policy_arn, cloudwatch_agent_policy = module.jenkins_cloudwatch_agent_policy.policy_arn }
   private_ip          = "10.0.1.222"
   user_data           = "user_data_jenkins_docker"
   user_data_variables = { jenkins_cluster_name = "jenkins-prod-${local.environment}", agent_policy_parameter_name = "/${local.environment}/cloudwatch/agent/production/policy" }


### PR DESCRIPTION
Add modules for disk space alerting. 

* An SSM parameter for the cloudwatch agent config
* A mgmt notifications topic to send the alerts to slack
* A policy to allow the EC2 instance agent to push to cloudwatch
* A cloudwatch alarm for each Jenkins instance which will alert when the disk space is full.