### PR TITLE
Upgrade libgrypt

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/jenkins:2.306-alpine
 USER root
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'\" ${JAVA_OPTS:-}"
 RUN apk update && \
-        apk upgrade openssl apk-tools && \
+        apk upgrade openssl apk-tools libgcrypt && \
         apk add py3-pip zip make && \
         mkdir -p /opt/jcasc && \
         addgroup docker && \

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -2,7 +2,7 @@ FROM jenkins/jenkins:2.306-alpine
 USER root
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false ${JAVA_OPTS:-}"
 RUN apk update && \
-        apk upgrade openssl apk-tools && \
+        apk upgrade openssl apk-tools libgcrypt && \
         apk add py3-pip zip make && \
         mkdir -p /opt/jcasc && \
         addgroup docker && \


### PR DESCRIPTION
There is a vulnerability on libgrypt but we can't upgrade Jenkins until
we've changed our builds to say controller instead of master so we need
to upgrade the package instead.
