### PR TITLE
Add slack-release-channel to jenkins-prod

### DIFF
--- a/docker/jenkins-prod.yml
+++ b/docker/jenkins-prod.yml
@@ -31,6 +31,10 @@ credentials:
           id: "npm-login"
           scope: GLOBAL
           secret: ${/mgmt/npm_token}
+      - string:
+          id: "slack-release-channel"
+          scope: GLOBAL
+          secret: ${/mgmt/release/slack/webhook}
 jenkins:
   securityRealm:
     github:


### PR DESCRIPTION
We need this for the github release versions job. I'm not sure how it
worked before, probably I added it in manually.
