### PR TITLE
Set aws jenkins node image version to 4.10

### DIFF
--- a/docker/nodes/aws/Dockerfile
+++ b/docker/nodes/aws/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:alpine
+FROM jenkins/inbound-agent:4.10-2-alpine
 USER root
 RUN apk update \
     && apk add curl wget py3-pip gcc python3-dev musl-dev libffi-dev openssl-dev jansson-dev build-base libc-dev file-dev automake autoconf libtool flex bison unzip \


### PR DESCRIPTION
The latest version of the 'jenkins/inbound-agent' causes builds to fail