### PR TITLE
Stop using patched oauth plugin

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,6 @@ COPY jenkins.yml /usr/share/jenkins/ref/jenkins.yaml
 # to preserve the correct permissions on the /var/jenkins_home/plugins directory
 COPY --chown=jenkins backup.sh /opt/backup.sh
 COPY --chown=jenkins logging.groovy /var/jenkins_home/init.groovy.d/logging.groovy
-COPY --chown=jenkins github-oauth.hpi /var/jenkins_home/plugins/
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt && chmod +x /opt/backup.sh
 COPY entrypoint.sh .
 

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -21,7 +21,6 @@ COPY jenkins-prod.yml /usr/share/jenkins/ref/jenkins.yaml
 # to preserve the correct permissions on the /var/jenkins_home/plugins directory
 COPY --chown=jenkins backup-prod.sh /opt/backup.sh
 COPY --chown=jenkins logging.groovy /var/jenkins_home/init.groovy.d/logging.groovy
-COPY --chown=jenkins github-oauth.hpi /var/jenkins_home/plugins/
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt && chmod +x /opt/backup.sh
 COPY entrypoint-prod.sh ./entrypoint.sh
 

--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -31,6 +31,7 @@ git-server:1.10
 github:1.34.1
 github-api:1.133
 github-branch-source:2.11.3
+github-oauth:0.35
 handlebars:3.0.8
 hsts-filter-plugin:1.0
 htmlpublisher:1.28


### PR DESCRIPTION
My changes to the github oauth plugin have been merged and a new release produced so we should now be able to use the official version of the plugin.