### PR TITLE
Rebuild nodes on a schedule

### DIFF
--- a/Jenkinsfile-scheduled-node-build
+++ b/Jenkinsfile-scheduled-node-build
@@ -11,12 +11,12 @@ pipeline {
           def nodeNames = ["aws", "npm", "plugin-updates", "postgres", "terraform", "transfer-frontend", "terraform-latest"]
           nodeNames.each() { String jobName ->
             build(
-                job: "TDR Build Jenkins Node Images",
-                parameters: [
-                    string(name: "BRANCH", value: "master"),
-                    string(name: "ECR_REPOSITORY", value: "mgmt"),
-                    string(name: "JENKINS_NODE", value: jobName)
-                ])
+              job: "TDR Build Jenkins Node Images",
+              parameters: [
+                string(name: "BRANCH", value: "master"),
+                string(name: "ECR_REPOSITORY", value: "mgmt"),
+                string(name: "JENKINS_NODE", value: jobName)
+              ])
           }
         }
       }

--- a/Jenkinsfile-scheduled-node-build
+++ b/Jenkinsfile-scheduled-node-build
@@ -16,7 +16,7 @@ pipeline {
                     string(name: "BRANCH", value: "master"),
                     string(name: "ECR_REPOSITORY", value: "mgmt"),
                     string(name: "JENKINS_NODE", value: jobName)
-                ], wait: false)
+                ])
           }
         }
       }

--- a/Jenkinsfile-scheduled-node-build
+++ b/Jenkinsfile-scheduled-node-build
@@ -1,0 +1,37 @@
+pipeline {
+  agent {
+    label "built-in"
+  }
+  stages {
+    stage("Rebuild nodes") {
+      script {
+        def nodeNames = ["aws", "npm", "plugin-updates", "postgres", "terraform", "transfer-frontend", "terraform-latest"]
+        nodeNames.each() { String jobName ->
+          build(
+              job: "TDR Build Jenkins Node Images",
+              parameters: [
+                  string(name: "BRANCH", value: "master"),
+                  string(name: "ECR_REPOSITORY", value: "mgmt"),
+                  string(name: "JENKINS_NODE", value: jobName)
+              ], wait: false)
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      script {
+        tdr.postToDaTdrSlackChannel(colour: "danger",
+            message: "*Jenkins scheduled node rebuild* :warning: The scheduled rebuild of the Jenkins nodes has failed"
+        )
+      }
+    }
+    success {
+      script {
+        tdr.postToDaTdrSlackChannel(colour: "good",
+            message: "*Jenkins scheduled node rebuild* All Jenkins nodes have been rebuilt"
+        )
+      }
+    }
+  }
+}

--- a/Jenkinsfile-scheduled-node-build
+++ b/Jenkinsfile-scheduled-node-build
@@ -1,3 +1,5 @@
+library("tdr-jenkinslib")
+
 pipeline {
   agent {
     label "built-in"

--- a/Jenkinsfile-scheduled-node-build
+++ b/Jenkinsfile-scheduled-node-build
@@ -4,16 +4,18 @@ pipeline {
   }
   stages {
     stage("Rebuild nodes") {
-      script {
-        def nodeNames = ["aws", "npm", "plugin-updates", "postgres", "terraform", "transfer-frontend", "terraform-latest"]
-        nodeNames.each() { String jobName ->
-          build(
-              job: "TDR Build Jenkins Node Images",
-              parameters: [
-                  string(name: "BRANCH", value: "master"),
-                  string(name: "ECR_REPOSITORY", value: "mgmt"),
-                  string(name: "JENKINS_NODE", value: jobName)
-              ], wait: false)
+      steps {
+        script {
+          def nodeNames = ["aws", "npm", "plugin-updates", "postgres", "terraform", "transfer-frontend", "terraform-latest"]
+          nodeNames.each() { String jobName ->
+            build(
+                job: "TDR Build Jenkins Node Images",
+                parameters: [
+                    string(name: "BRANCH", value: "master"),
+                    string(name: "ECR_REPOSITORY", value: "mgmt"),
+                    string(name: "JENKINS_NODE", value: jobName)
+                ], wait: false)
+          }
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -182,6 +182,13 @@ Set the following parameters to build and push the image to the sandbox ECR:
 * ECR_REPOSITORY: `sandbox`
 * JENKINS_NODE: `[select node image from drop down list]`
 
+#### Periodically update the containers
+We are getting a number of vulnerabilities from the regular image scan in the Jenkins node images. The solution is usually to rebuild them using the Jenkins job above. 
+
+To try to reduce the amount of time we spend running this job, there is a new Jenkins job defined in [Jenkinsfile-scheduled-node-build](./Jenkinsfile-scheduled-node-build) 
+
+This job runs once a week and will call the [TDR Build Jenkins Node Images][TDR Build Jenkins Node Images] job for each of the node images. We don't build the Jenkins docker images themselves as these are usually done when there are plugin updates or a new Jenkins version. 
+
 #### Add a new container
 
 The docker container must start with `FROM jenkins/inbound-agent:alpine` This image is mostly stock Alpine Linux and from there, you need to install whatever it is you need for your build:

--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -241,7 +241,7 @@ jenkins:
   markupFormatter: "plainText"
   mode: EXCLUSIVE
   myViewsTabBar: "standard"
-  numExecutors: 6
+  numExecutors: 15
   primaryView:
     all:
       name: "all"

--- a/docker/jenkins.yml
+++ b/docker/jenkins.yml
@@ -241,7 +241,7 @@ jenkins:
   markupFormatter: "plainText"
   mode: EXCLUSIVE
   myViewsTabBar: "standard"
-  numExecutors: 15
+  numExecutors: 12
   primaryView:
     all:
       name: "all"


### PR DESCRIPTION
Add Jenkinsfile to rebuild node images.
    
This will be run on a schedule. This is to try and stop the vulnerabilities we're getting every other week. 

I've left the jenkins images themselves as they're updated manually when there are plugin or version updates.
