### PR TITLE
Prevent Jenkins terraform creating hosted zone

### DIFF
--- a/terraform/root_data.tf
+++ b/terraform/root_data.tf
@@ -30,3 +30,7 @@ data "aws_caller_identity" "current" {}
 data "aws_ssm_parameter" "sandbox_account" {
   name = "/mgmt/sandbox_account"
 }
+
+data "aws_route53_zone" "hosted_zone" {
+  name = "tdr-management.nationalarchives.gov.uk"
+}

--- a/terraform/root_integration.tf
+++ b/terraform/root_integration.tf
@@ -28,6 +28,7 @@ module "jenkins_integration_dns" {
   alb_zone_id           = module.jenkins_integration_alb.alb_zone_id
   a_record_name         = "jenkins"
   create_hosted_zone    = false
+  hosted_zone_id        = data.aws_route53_zone.hosted_zone.id
 }
 
 module "jenkins_integration_ec2" {

--- a/terraform/root_integration.tf
+++ b/terraform/root_integration.tf
@@ -27,6 +27,7 @@ module "jenkins_integration_dns" {
   alb_dns_name          = module.jenkins_integration_alb.alb_dns_name
   alb_zone_id           = module.jenkins_integration_alb.alb_zone_id
   a_record_name         = "jenkins"
+  create_hosted_zone    = false
 }
 
 module "jenkins_integration_ec2" {

--- a/terraform/root_production.tf
+++ b/terraform/root_production.tf
@@ -28,6 +28,7 @@ module "jenkins_dns_prod" {
   alb_zone_id           = module.jenkins_alb_prod.alb_zone_id
   a_record_name         = "jenkins-prod"
   create_hosted_zone    = false
+  hosted_zone_id        = data.aws_route53_zone.hosted_zone.id
 }
 
 module "jenkins_ec2_prod" {

--- a/terraform/root_production.tf
+++ b/terraform/root_production.tf
@@ -27,6 +27,7 @@ module "jenkins_dns_prod" {
   alb_dns_name          = module.jenkins_alb_prod.alb_dns_name
   alb_zone_id           = module.jenkins_alb_prod.alb_zone_id
   a_record_name         = "jenkins-prod"
+  create_hosted_zone    = false
 }
 
 module "jenkins_ec2_prod" {


### PR DESCRIPTION
Changes already deployed and Terraform state manually updated to remove references to the hosted zones

The hosted zones are created within the tdr-aws-accounts Terraform

Jenkins Terraform was inadvertently overwriting the hosted zones

Set parameter 'create_host_zone' to false to prevent this happening in the future

The hosted zone AWS resource needs to be manually removed from the Jenkins Terraform state file, to prevent deletion of the existing hosted zone AWS resource