### PR TITLE
Upgrade expat.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/jenkins:2.333-alpine
 USER root
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'\" ${JAVA_OPTS:-}"
 RUN apk update && \
-        apk upgrade openssl apk-tools libgcrypt curl nettle busybox && \
+        apk upgrade openssl apk-tools libgcrypt curl nettle busybox expat && \
         apk add py3-pip zip make && \
         mkdir -p /opt/jcasc && \
         addgroup docker && \

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -2,7 +2,7 @@ FROM jenkins/jenkins:2.333-alpine
 USER root
 ENV JAVA_OPTS "-Djenkins.install.runSetupWizard=false ${JAVA_OPTS:-}"
 RUN apk update && \
-        apk upgrade openssl apk-tools libgcrypt curl nettle busybox && \
+        apk upgrade openssl apk-tools libgcrypt curl nettle busybox expat && \
         apk add py3-pip zip make && \
         mkdir -p /opt/jcasc && \
         addgroup docker && \


### PR DESCRIPTION
There are two CVEs for this library
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23852
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-23990

The upgrade has fixed the vulnerability. This has already been deployed.